### PR TITLE
Fixed tiny typo in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The default key bindings for this plugin:
 
 ### Command Palette
 
-Open the command palette, it apperas as `SublimeAStyleFormatter: Format Current File` and
+Open the command palette, it appears as `SublimeAStyleFormatter: Format Current File` and
 `SublimeAStyleFormatter Format Current Selection`.
 
 Settings


### PR DESCRIPTION
I fixed a tiny typo in the README as I was just about to install your package on my version of Sublime Text.
