### PR TITLE
Remove indent-preprocessor from options

### DIFF
--- a/AStyleFormatterLib/Options.py
+++ b/AStyleFormatterLib/Options.py
@@ -144,7 +144,6 @@ g_setting_option_map = {
     "indent-cases":             process_option_generic,
     "indent-namespaces":        process_option_generic,
     "indent-labels":            process_option_generic,
-    "indent-preprocessor":      process_option_generic,
     "indent-preproc-define":    process_option_generic,
     "indent-preproc-cond":      process_option_generic,
     "indent-col1-comments":     process_option_generic,


### PR DESCRIPTION
`indent-preprocessor` option has been deprecated since v2.04 and not listed in the plugin's settings file either. The side-effect is that if I set `indent-preproc-define` false (which is true by default), the `indent-preprocessor` option still sneaks into the options array.